### PR TITLE
Migrate to riverpod v0.14

### DIFF
--- a/riverpod_simplified/lib/main.dart
+++ b/riverpod_simplified/lib/main.dart
@@ -26,7 +26,8 @@ class Home extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             Consumer(
-              builder: (BuildContext context, T Function<T>(ProviderBase<Object, T>) watch, Widget child) {
+              builder: (BuildContext context,
+                  T Function<T>(ProviderBase<Object, T>) watch, Widget child) {
                 return watch(userProvider("Tadas")).maybeWhen(
                   data: (String value) {
                     return Text(value);
@@ -41,16 +42,18 @@ class Home extends StatelessWidget {
               height: 100,
             ),
             Consumer(
-              builder: (BuildContext context, T Function<T>(ProviderBase<Object, T>) watch, Widget child) {
-                return Text("Basic: " + watch(counterController.state).toString());
+              builder: (BuildContext context,
+                  T Function<T>(ProviderBase<Object, T>) watch, Widget child) {
+                return Text("Basic: " + watch(counterController).toString());
               },
             ),
             SizedBox(
               height: 100,
             ),
             Consumer(
-              builder: (BuildContext context, T Function<T>(ProviderBase<Object, T>) watch, Widget child) {
-                return watch(counterAsyncController.state).when(
+              builder: (BuildContext context,
+                  T Function<T>(ProviderBase<Object, T>) watch, Widget child) {
+                return watch(counterAsyncController).when(
                   data: (int value) {
                     return Text("AsyncValue: " + value.toString());
                   },
@@ -66,18 +69,18 @@ class Home extends StatelessWidget {
             SizedBox(
               height: 100,
             ),
-            RaisedButton(
+            ElevatedButton(
               child: Text("Add"),
               onPressed: () {
-                context.read(counterController).add();
-                context.read(counterAsyncController).add();
+                context.read(counterController.notifier).add();
+                context.read(counterAsyncController.notifier).add();
               },
             ),
-            RaisedButton(
+            ElevatedButton(
               child: Text("Subtract"),
               onPressed: () {
-                context.read(counterController).subtract();
-                context.read(counterAsyncController).subtract();
+                context.read(counterController.notifier).subtract();
+                context.read(counterAsyncController.notifier).subtract();
               },
             )
           ],

--- a/riverpod_simplified/lib/providers.dart
+++ b/riverpod_simplified/lib/providers.dart
@@ -3,7 +3,8 @@ import 'package:simple_example/database.dart';
 import 'package:state_notifier/state_notifier.dart';
 
 // user state for the app
-final userProvider = FutureProvider.autoDispose.family<String, String>((ref, str) async {
+final userProvider =
+    FutureProvider.autoDispose.family<String, String>((ref, str) async {
   if (str == "Tadas") {
     return "Good Tadas";
   }
@@ -11,7 +12,8 @@ final userProvider = FutureProvider.autoDispose.family<String, String>((ref, str
 });
 
 // counter state notifier for the app
-final counterController = StateNotifierProvider<CounterNotifier>((ref) => CounterNotifier());
+final counterController =
+    StateNotifierProvider<CounterNotifier, int>((ref) => CounterNotifier());
 
 class CounterNotifier extends StateNotifier<int> {
   CounterNotifier() : super(0);
@@ -26,7 +28,9 @@ class CounterNotifier extends StateNotifier<int> {
 }
 
 // async state notifier provider for state that doesn't change in real time
-final counterAsyncController = StateNotifierProvider<CounterAsyncNotifier>((ref) => CounterAsyncNotifier(ref.read));
+final counterAsyncController =
+    StateNotifierProvider<CounterAsyncNotifier, AsyncValue<int>>(
+        (ref) => CounterAsyncNotifier(ref.read));
 
 class CounterAsyncNotifier extends StateNotifier<AsyncValue<int>> {
   CounterAsyncNotifier(this.read) : super(AsyncLoading()) {

--- a/riverpod_simplified/pubspec.lock
+++ b/riverpod_simplified/pubspec.lock
@@ -7,42 +7,42 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety.1"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.3"
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.3"
+    version: "1.15.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -56,7 +56,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -68,7 +68,7 @@ packages:
       name: flutter_riverpod
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.1"
+    version: "0.14.0+3"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -80,42 +80,42 @@ packages:
       name: freezed_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.0+1"
+    version: "0.14.2"
   json_annotation:
     dependency: transitive
     description:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "4.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety.1"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.1"
+    version: "1.8.0"
   riverpod:
     dependency: transitive
     description:
       name: riverpod
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.8.0"
+    version: "0.14.0+3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -127,63 +127,63 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.2"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.1"
+    version: "1.10.0"
   state_notifier:
     dependency: transitive
     description:
       name: state_notifier
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.0"
+    version: "0.7.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety.2"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.3"
+    version: "2.1.0"
 sdks:
-  dart: ">=2.10.0-110 <2.11.0"
+  dart: ">=2.12.0 <3.0.0"
   flutter: ">=1.17.0"


### PR DESCRIPTION
Minor changes needed for riverpod v0.14. [See](https://riverpod.dev/docs/migration/0.13.0_to_0.14.0)
Thank you for a good example and great videos!!! 